### PR TITLE
fix: geocodeLocation location_type バリデーション追加（#445）

### DIFF
--- a/scripts/crawl/enrich-event.js
+++ b/scripts/crawl/enrich-event.js
@@ -32,7 +32,10 @@ async function geocodeLocation(location, apiKey) {
   )
   const data = await res.json()
   if (data.status !== 'OK' || !data.results?.length) return null
-  return data.results[0].geometry.location // { lat, lng }
+  const result = data.results[0]
+  const locationType = result.geometry.location_type
+  if (locationType === 'GEOMETRIC_CENTER' || locationType === 'APPROXIMATE') return null
+  return result.geometry.location // { lat, lng }
 }
 
 async function searchNearbyLodging(lat, lng, apiKey) {


### PR DESCRIPTION
## 概要

geocodeLocation() 関数にGoogle Geocoding API結果の精度チェックを追加しました。

## 修正内容

GEOMETRIC_CENTER または APPROXIMATE の location_type を返す結果を拒否し、null を返すようにしました。

これにより以下の問題を防止します:
- 海上座標の登録
- 誤座標の登録

## 修正ファイル

- scripts/crawl/enrich-event.js

## テスト

- npx tsc --noEmit: ✓ エラーなし

## 関連Issue

#445