### PR TITLE
fix: collect-races ノイズフィルタ強化（vts-photo + FAQ/About除外）

### DIFF
--- a/scripts/crawl/collect-races.js
+++ b/scripts/crawl/collect-races.js
@@ -94,9 +94,22 @@ const JUNK_URL_PATTERNS = [
   /\/(archives?|page\/\d+)(\/|$|\?)/i,
 ]
 
+/** ドメイン別ノイズパターン */
+const DOMAIN_JUNK_PATTERNS = [
+  { domain: 'vts-photo.vietnamtrailseries.com', paths: [''] }, // 全パスを除外
+  { domain: 'marathon.tokyo', paths: ['/about/', '/program/', '/course/'] },
+  { domain: 'info.runsignup.com', paths: ['/about-us/', '/products/'] },
+  { domain: 'event-organizer.jp', paths: ['/faq/'] },
+]
+
 function isJunkUrl(url) {
   if (!url) return false
-  return JUNK_URL_PATTERNS.some((p) => p.test(url))
+  if (JUNK_URL_PATTERNS.some((p) => p.test(url))) return true
+  // ドメイン別ノイズパターンチェック
+  if (DOMAIN_JUNK_PATTERNS.some(({ domain, paths }) =>
+    url.includes(domain) && (paths[0] === '' || paths.some(path => url.includes(path)))
+  )) return true
+  return false
 }
 
 /** ホームページURL（パスなし or /のみ）はnullに変換 */


### PR DESCRIPTION
## 概要

collect-races.js の isJunkUrl() 関数を強化し、collect品質の向上を図りました。

## 修正内容

### 修正1: vts-photo.vietnamtrailseries.com を除外
- Vietnam Trail Series の写真アーカイブサイト
- 15件がノイズとして混入していた
- 全パスを除外対象に

### 修正2: ドメイン別ノイズパターンを追加
- FAQ/About/Course等の非イベントページを除外
- ドメイン別ホワイトリスト方式で管理
- 特定ドメインのみに限定（誤検知回避）

**対象ドメイン:**
- vts-photo.vietnamtrailseries.com
- marathon.tokyo（/about/, /program/, /course/）
- info.runsignup.com（/about-us/, /products/）
- event-organizer.jp（/faq/）

## 修正ファイル

- scripts/crawl/collect-races.js

## テスト

- npx tsc --noEmit: ✓ エラーなし