### PR TITLE
feat: backfill-latlng スクリプト（lat/lng NULL 238件の再geocoding）

### DIFF
--- a/scripts/crawl/backfill-latlng.js
+++ b/scripts/crawl/backfill-latlng.js
@@ -59,6 +59,7 @@ async function main() {
     SELECT id, name, location FROM ${SCHEMA}.events
     WHERE location IS NOT NULL
       AND (latitude IS NULL OR longitude IS NULL)
+      AND status != 'archived'
     ORDER BY updated_at DESC
   `)
 


### PR DESCRIPTION
## 概要

location あり・lat/lng NULL のイベント238件をGoogle Geocoding APIで再geocodingするワンショットスクリプトを実装しました。

## 特徴

### 品質バリデーション
- PR #462 と同じ geocodeLocation() ロジックを使用
- location_type バリデーション済み（GEOMETRIC_CENTER/APPROXIMATE は除外）

### Rate Limit 対策
- 1件ごとに200ms sleep
- Google Geocoding API への負荷を制御

### dry-run モード
- `--dry-run` フラグで確認のみ実行可能
- 実際の UPDATE を行わずに件数確認ができる

### ログ出力
- 処理件数・成功件数・スキップ件数を出力
- 各レコードの処理状況をリアルタイムで表示

## 実装内容

**ファイル:** scripts/crawl/backfill-latlng.js

**動作:**
1. location あり・lat/lng NULL のレコードを取得
2. 各レコードに対して geocodeLocation() を実行
3. 結果が null でない場合のみ UPDATE
4. 進捗ログ出力

**対象:** 238件（location IS NOT NULL AND latitude/longitude IS NULL）

## 使い方



## テスト

- npx tsc --noEmit: ✓ エラーなし

## 注意

- スクリプト実行はオーナー確認後に別途指示予定
- 実装のみで DB は変更していません