### PR TITLE
fix: isJunkUrl にFacebook・Zoom・JustRunLahを追加除外

### DIFF
--- a/scripts/crawl/collect-races.js
+++ b/scripts/crawl/collect-races.js
@@ -100,6 +100,9 @@ const DOMAIN_JUNK_PATTERNS = [
   { domain: 'marathon.tokyo', paths: ['/about/', '/program/', '/course/'] },
   { domain: 'info.runsignup.com', paths: ['/about-us/', '/products/'] },
   { domain: 'event-organizer.jp', paths: ['/faq/'] },
+  { domain: 'facebook.com', paths: [''] }, // SNS団体ページ
+  { domain: 'events.zoom.us', paths: [''] }, // Zoomウェビナーページ
+  { domain: 'connect.justrunlah.com', paths: [''] }, // JustRunLahチケットHP
 ]
 
 function isJunkUrl(url) {


### PR DESCRIPTION
## 概要

collect-races.js の isJunkUrl() 関数に、Facebook団体ページ・Zoomウェビナーページ・JustRunLahチケットHPを除外対象として追加しました。

## 修正内容

DOMAIN_JUNK_PATTERNS に以下3つのドメインを追加:

- **facebook.com**: SNS団体ページ（全パス除外）
- **events.zoom.us**: Zoomウェビナーページ（全パス除外）
- **connect.justrunlah.com**: JustRunLahチケットHP（全パス除外）

## 修正ファイル

- scripts/crawl/collect-races.js

## テスト

- npx tsc --noEmit: ✓ エラーなし